### PR TITLE
Add facet search support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,72 @@ To delete a record from the search engine:
 searchEngine.DeleteRecord(1);
 ```
 
+### Pagination
+
+In addition to basic searching, you can easily implement pagination using the `skip` and `limit` parameters in the `Search` method. This is especially useful when dealing with large datasets where you only want to display a subset of the results at a time.
+
+```csharp
+var resultsPage1 = searchEngine.Search(
+    search: "quick fox",
+    respectTokenOrder: true,
+    skip: 0, // Skip 0 records, start from the beginning
+    limit: 10 // Limit to 10 records in this page
+);
+
+var resultsPage2 = searchEngine.Search(
+    search: "quick fox",
+    respectTokenOrder: true,
+    skip: 10, // Skip the first 10 records
+    limit: 10 // Limit to 10 records in this page
+);
+```
+
+### Adding Facets
+
+To associate a facet (e.g., category, author) with a record:
+
+```csharp
+searchEngine.AddFacet(1, "category", "books");
+searchEngine.AddFacet(1, "author", "John Doe");
+```
+
+### Deleting Facets
+
+To remove a specific facet associated with a record:
+
+```csharp
+searchEngine.DeleteFacet(1, "category", "books");
+searchEngine.DeleteFacet(1, "author", "John Doe");
+```
+
+### Faceted Search
+
+If you're also filtering by facets, you can still apply pagination by specifying the `skip` and `limit` parameters:
+
+```csharp
+var facets = new Dictionary<string, string>
+{
+    { "category", "books" },
+    { "author", "John Doe" }
+};
+
+var paginatedFacetedResultsPage1 = searchEngine.Search(
+    search: "quick fox",
+    facets: facets,
+    respectTokenOrder: true,
+    skip: 0, // Start from the first matching record
+    limit: 10 // Retrieve up to 10 records
+);
+
+var paginatedFacetedResultsPage2 = searchEngine.Search(
+    search: "quick fox",
+    facets: facets,
+    respectTokenOrder: true,
+    skip: 10, // Skip the first 10 matching records
+    limit: 10 // Retrieve the next 10 records
+);
+```
+
 ### Cleanup
 
 When you're done using the search engine, ensure proper cleanup:
@@ -259,7 +325,7 @@ Future Search Engines: Additional search engines, such as Phrase Search Engine a
 
 ## License
 
-ZoneTree.FullTextSearch is licensed under the MIT License. See the [LICENSE](LICENSE) file for more details.
+ZoneTree.FullTextSearch is licensed under the MIT License. See the [LICENSE](https://github.com/koculu/ZoneTree.FullTextSearch/blob/main/LICENSE) file for more details.
 
 ---
 

--- a/src/ZoneTree.FullTextSaearch/Directory.Build.props
+++ b/src/ZoneTree.FullTextSaearch/Directory.Build.props
@@ -5,8 +5,8 @@
     <Authors>Ahmed Yasin Koculu</Authors>
     <PackageId>ZoneTree.FullTextSearch</PackageId>
     <Title>ZoneTree.FullTextSearch</Title>
-    <ProductVersion>1.0.0.0</ProductVersion>
-    <Version>1.0.0.0</Version>
+    <ProductVersion>1.0.1.0</ProductVersion>
+    <Version>1.0.1.0</Version>
     <Authors>Ahmed Yasin Koculu</Authors>
     <AssemblyTitle>ZoneTree.FullTextSearch</AssemblyTitle>
     <Description>ZoneTree.FullTextSearch is an open-source library that extends ZoneTree to provide efficient full-text search capabilities. It offers a fast, embedded search engine suitable for applications that require high performance and do not rely on external databases.</Description>

--- a/src/ZoneTree.FullTextSaearch/RecordTable.cs
+++ b/src/ZoneTree.FullTextSaearch/RecordTable.cs
@@ -119,8 +119,8 @@ public sealed class RecordTable<TRecord, TValue> : IDisposable where TRecord : u
         ZoneTree1.IsReadOnly = true;
         ZoneTree2.IsReadOnly = true;
         isDropped = true;
-        ZoneTree1.Maintenance.DestroyTree();
-        ZoneTree2.Maintenance.DestroyTree();
+        ZoneTree1.Maintenance.Drop();
+        ZoneTree2.Maintenance.Drop();
         ZoneTree1.Dispose();
         ZoneTree2.Dispose();
     }

--- a/src/ZoneTree.FullTextSaearch/SearchEngines/HashedSearchEngine.cs
+++ b/src/ZoneTree.FullTextSaearch/SearchEngines/HashedSearchEngine.cs
@@ -1,4 +1,6 @@
-﻿using Tenray.ZoneTree;
+﻿using System;
+using System.Drawing;
+using Tenray.ZoneTree;
 using Tenray.ZoneTree.Comparers;
 using Tenray.ZoneTree.Core;
 using ZoneTree.FullTextSearch.Core;
@@ -43,6 +45,7 @@ public sealed class HashedSearchEngine<TRecord> : IDisposable
             new UInt64ComparerAscending(),
             useSecondaryIndex
             );
+        Index.FacetPreviousToken = ulong.MaxValue;
         WordTokenizer = wordTokenizer ?? new WordTokenizer();
     }
 
@@ -56,7 +59,28 @@ public sealed class HashedSearchEngine<TRecord> : IDisposable
         IWordTokenizer wordTokenizer = null)
     {
         Index = index;
+        Index.FacetPreviousToken = ulong.MaxValue;
         WordTokenizer = wordTokenizer ?? new WordTokenizer();
+    }
+
+    /// <summary>
+    /// Adds a new record to the index, associating it with the hashed tokens from the provided text.
+    /// </summary>
+    /// <param name="record">The record to add to the index.</param>
+    /// <param name="text">The text to tokenize and hash for indexing.</param>
+    public void AddRecord(TRecord record, string text)
+    {
+        var memory = text.AsMemory();
+        var previousToken = 0ul;
+        var slices = WordTokenizer.EnumerateSlices(memory).ToArray();
+        var len = slices.Length;
+        for (int i = 0; i < len; i++)
+        {
+            var slice = slices[i];
+            var token = HashCodeGenerator.GetHashCode(memory.Slice(slice));
+            Index.UpsertRecord(token, record, previousToken);
+            previousToken = token;
+        }
     }
 
     /// <summary>
@@ -69,37 +93,77 @@ public sealed class HashedSearchEngine<TRecord> : IDisposable
         return Index.DeleteRecord(record);
     }
 
-    /// <summary>
-    /// Adds a new record to the index, associating it with the hashed tokens from the provided text.
-    /// </summary>
-    /// <param name="record">The record to add to the index.</param>
-    /// <param name="text">The text to tokenize and hash for indexing.</param>
-    public void AddRecord(TRecord record, string text)
+    static ulong GetFacetToken(string name, string value)
     {
+        var text = $"{{${name}:{value}}}";
         var memory = text.AsMemory();
-        var previousToken = 0ul;
-        foreach (var slice in WordTokenizer.EnumerateSlices(memory))
-        {
-            var token = HashCodeGenerator.GetHashCode(memory.Slice(slice));
-            Index.UpsertRecord(token, record, previousToken);
-            previousToken = token;
-        }
+        return HashCodeGenerator.GetHashCode(memory);
+    }
+
+    static ulong[] GetFacetTokens(IReadOnlyDictionary<string, string> facets)
+    {
+        if (facets == null) return [];
+        return facets.Select(x => GetFacetToken(x.Key, x.Value)).ToArray();
     }
 
     /// <summary>
-    /// Searches for records that match the hashed tokens of the provided search string.
+    /// Adds or updates a single facet for the specified record.
     /// </summary>
-    /// <param name="search">The search string to tokenize and hash.</param>
-    /// <param name="respectTokenOrder">Indicates whether the order of tokens should be respected during the search.</param>
-    /// <param name="skip">The number of records to skip in the result set.</param>
-    /// <param name="limit">The maximum number of records to return.</param>
-    /// <returns>An array of records that match the search criteria.</returns>
+    /// <param name="record">The record to which the facet will be added or updated.</param>
+    /// <param name="name">The name of the facet (e.g., "category", "author").</param>
+    /// <param name="value">The value of the facet (e.g., "books", "John Doe").</param>
+    public void AddFacet(TRecord record, string name, string value)
+    {
+        var token = GetFacetToken(name, value);
+        Index.UpsertRecord(token, record, Index.FacetPreviousToken);
+    }
+
+    /// <summary>
+    /// Deletes a specific facet associated with the specified record from the index.
+    /// </summary>
+    /// <param name="record">The record from which the facet will be deleted.</param>
+    /// <param name="name">The name of the facet to delete (e.g., "category", "author").</param>
+    /// <param name="value">The value of the facet to delete (e.g., "books", "John Doe").</param>
+    public void DeleteFacet(TRecord record, string name, string value)
+    {
+        var token = GetFacetToken(name, value);
+        Index.DeleteRecord(token, record, Index.FacetPreviousToken);
+    }
+
+    /// <summary>
+    /// Searches the index based on a search string, with optional token order respect and pagination.
+    /// </summary>
+    /// <param name="search">
+    /// The search string containing the terms to look for in the index. 
+    /// This string is tokenized internally to identify individual search tokens.
+    /// The search terms are logically grouped using "AND", meaning all terms must be present in the matching records.
+    /// If the search string is empty or null, the result will be an empty array. 
+    /// Retrieving all records via the full-text index is avoided for performance reasons.
+    /// In such cases, it is recommended to fetch records from the actual record source instead of using the search index.
+    /// </param>
+    /// <param name="respectTokenOrder">
+    /// A boolean indicating whether the search should respect the order of tokens in the search string. 
+    /// If true, the records must contain the tokens in the same order as they appear in the search string.
+    /// </param>
+    /// <param name="skip">
+    /// The number of matching records to skip in the result set, useful for pagination. 
+    /// Defaults to 0.
+    /// </param>
+    /// <param name="limit">
+    /// The maximum number of records to return, useful for limiting the result set size. 
+    /// Defaults to 0, which indicates no limit.
+    /// </param>
+    /// <returns>
+    /// An array of records that match the search string, respecting the token order if specified. 
+    /// The array may be empty if no matching records are found.
+    /// </returns>
     public TRecord[] Search(
         string search,
         bool respectTokenOrder = true,
         int skip = 0,
         int limit = 0)
     {
+        if (string.IsNullOrWhiteSpace(search)) return [];
         var memory = search.AsMemory();
         var slices = WordTokenizer.GetSlices(search);
         if (slices.Count == 0) return [];
@@ -109,7 +173,78 @@ public sealed class HashedSearchEngine<TRecord> : IDisposable
             .Select(slice => HashCodeGenerator.GetHashCode(memory.Slice(slice)))
             .ToArray();
         return Index
-            .Search(tokens, longestToken, respectTokenOrder, skip, limit);
+            .Search(tokens, longestToken, respectTokenOrder, default, skip, limit);
+    }
+
+    /// <summary>
+    /// Searches the index based on a search string, with optional facet filters, token order respect, and pagination.
+    /// </summary>
+    /// <param name="search">
+    /// The search string containing the terms to look for in the index. 
+    /// This string is tokenized internally to identify individual search tokens.
+    /// The search terms are logically grouped using "AND", meaning all terms must be present in the matching records.
+    /// If the search string is empty or null, the search will still be performed if facets are provided.
+    /// However, if both the search string and facets are empty or null, the result will be an empty array, as searching without any criteria is not supported.
+    /// Retrieving all records via the full-text index is avoided for performance reasons.
+    /// In such cases, it is recommended to fetch records from the actual record source instead of using the search index.
+    /// </param>
+    /// <param name="facets">
+    /// A dictionary of facet filters where the key represents the facet field and the value represents the required facet value.
+    /// The facets are logically grouped using "OR", meaning the records must match at least one of the specified facet values if any facets are provided.
+    /// If the dictionary is empty or null, no facet filtering is applied, and all matching records are returned regardless of facet values.
+    /// </param>
+    /// <param name="respectTokenOrder">
+    /// A boolean indicating whether the search should respect the order of tokens in the search string. 
+    /// If true, the records must contain the tokens in the same order as they appear in the search string.
+    /// </param>
+    /// <param name="skip">
+    /// The number of matching records to skip in the result set, useful for pagination. 
+    /// Defaults to 0.
+    /// </param>
+    /// <param name="limit">
+    /// The maximum number of records to return, useful for limiting the result set size. 
+    /// Defaults to 0, which indicates no limit.
+    /// </param>
+    /// <returns>
+    /// An array of records that match the search string and facet filters, respecting the token order if specified. 
+    /// The array may be empty if no matching records are found.
+    /// </returns>
+    public TRecord[] Search(
+        string search,
+        IReadOnlyDictionary<string, string> facets,
+        bool respectTokenOrder = true,
+        int skip = 0,
+        int limit = 0)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            var facetTokens = GetFacetTokens(facets);
+            if (facetTokens.Length == 0) return [];
+            return Index
+            .Search(
+                [],
+                default,
+                respectTokenOrder,
+                facetTokens,
+                skip,
+                limit);
+        }
+        var memory = search.AsMemory();
+        var slices = WordTokenizer.GetSlices(search);
+        if (slices.Count == 0) return [];
+        var longestSlice = slices.MaxBy(x => x.Length);
+        var longestToken = HashCodeGenerator.GetHashCode(memory.Slice(longestSlice));
+        var tokens = slices
+            .Select(slice => HashCodeGenerator.GetHashCode(memory.Slice(slice)))
+            .ToArray();
+        return Index
+            .Search(
+                tokens,
+                longestToken,
+                respectTokenOrder,
+                GetFacetTokens(facets),
+                skip,
+                limit);
     }
 
     /// <summary>
@@ -120,11 +255,15 @@ public sealed class HashedSearchEngine<TRecord> : IDisposable
         Index.Drop();
     }
 
+    bool isDisposed = false;
+
     /// <summary>
     /// Disposes the resources used by the search engine.
     /// </summary>
     public void Dispose()
     {
+        if (isDisposed) return;
+        isDisposed = true;
         Index.IsReadOnly = true;
         Index.WaitForBackgroundThreads();
         Index.Dispose();

--- a/src/ZoneTree.FullTextSaearch/ZoneTree.FullTextSaearch.csproj
+++ b/src/ZoneTree.FullTextSaearch/ZoneTree.FullTextSaearch.csproj
@@ -38,7 +38,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ZoneTree" Version="1.7.6" />
+    <PackageReference Include="ZoneTree" Version="1.7.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ZoneTree.FullTextSaearch/docs/ZoneTree.FullTextSearch/README-NUGET.md
+++ b/src/ZoneTree.FullTextSaearch/docs/ZoneTree.FullTextSearch/README-NUGET.md
@@ -1,6 +1,7 @@
 # ZoneTree.FullTextSearch
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
+[![Downloads](https://img.shields.io/nuget/dt/ZoneTree.FullTextSearch)](https://www.nuget.org/packages/ZoneTree.FullTextSearch/)
 ![Platform](https://img.shields.io/badge/platform-.NET-blue.svg)
 ![Build](https://img.shields.io/badge/build-passing-brightgreen.svg)
 
@@ -93,6 +94,72 @@ To delete a record from the search engine:
 
 ```csharp
 searchEngine.DeleteRecord(1);
+```
+
+### Pagination
+
+In addition to basic searching, you can easily implement pagination using the `skip` and `limit` parameters in the `Search` method. This is especially useful when dealing with large datasets where you only want to display a subset of the results at a time.
+
+```csharp
+var resultsPage1 = searchEngine.Search(
+    search: "quick fox",
+    respectTokenOrder: true,
+    skip: 0, // Skip 0 records, start from the beginning
+    limit: 10 // Limit to 10 records in this page
+);
+
+var resultsPage2 = searchEngine.Search(
+    search: "quick fox",
+    respectTokenOrder: true,
+    skip: 10, // Skip the first 10 records
+    limit: 10 // Limit to 10 records in this page
+);
+```
+
+### Adding Facets
+
+To associate a facet (e.g., category, author) with a record:
+
+```csharp
+searchEngine.AddFacet(1, "category", "books");
+searchEngine.AddFacet(1, "author", "John Doe");
+```
+
+### Deleting Facets
+
+To remove a specific facet associated with a record:
+
+```csharp
+searchEngine.DeleteFacet(1, "category", "books");
+searchEngine.DeleteFacet(1, "author", "John Doe");
+```
+
+### Faceted Search
+
+If you're also filtering by facets, you can still apply pagination by specifying the `skip` and `limit` parameters:
+
+```csharp
+var facets = new Dictionary<string, string>
+{
+    { "category", "books" },
+    { "author", "John Doe" }
+};
+
+var paginatedFacetedResultsPage1 = searchEngine.Search(
+    search: "quick fox",
+    facets: facets,
+    respectTokenOrder: true,
+    skip: 0, // Start from the first matching record
+    limit: 10 // Retrieve up to 10 records
+);
+
+var paginatedFacetedResultsPage2 = searchEngine.Search(
+    search: "quick fox",
+    facets: facets,
+    respectTokenOrder: true,
+    skip: 10, // Skip the first 10 matching records
+    limit: 10 // Retrieve the next 10 records
+);
 ```
 
 ### Cleanup

--- a/src/ZoneTree.FullTextSearch.Playground/Program.cs
+++ b/src/ZoneTree.FullTextSearch.Playground/Program.cs
@@ -5,11 +5,27 @@ namespace ZoneTree.FullTextSearch.Playground;
 
 public class Program
 {
-    static void Main()
+    static void Main(string[] args)
     {
         using var app = new SearchEngineApp();
+        if (args.Length > 0)
+        {
+            switch (args[0])
+            {
+                case "create":
+                    {
+                        app.CreateIndex(app.DefaultIndexPath, app.DefaultFilePattern, false);
+                        break;
+                    }
+                case "drop":
+                    {
+                        app.DropIndex(false);
+                        break;
+                    }
+            }
+            return;
+        }
         app.Run();
-        if (true) return;
     }
 }
 

--- a/src/ZoneTree.FullTextSearch.UnitTests/FacetTests.cs
+++ b/src/ZoneTree.FullTextSearch.UnitTests/FacetTests.cs
@@ -1,0 +1,84 @@
+﻿using ZoneTree.FullTextSaearch.SearchEngines;
+using ZoneTree.FullTextSearch.UnitTests.sampleData;
+
+namespace ZoneTree.FullTextSearch.UnitTests;
+
+public class FacetTests
+{
+    [Test]
+    public void TestFacetSearch()
+    {
+        var dataPath = "data/TestFacetSearch";
+        if (Directory.Exists(dataPath))
+            Directory.Delete(dataPath, true);
+        using var searchEngine = new HashedSearchEngine<long>(dataPath);
+
+        foreach (var product in ProductList.Products)
+        {
+            searchEngine.AddRecord(product.Id, product.ToString());
+            foreach (var prop in typeof(Facets).GetProperties())
+            {
+                var value = prop.GetValue(product.Facets);
+                if (value is string strValue)
+                {
+                    searchEngine.AddFacet(product.Id, prop.Name, strValue);
+                }
+                else if (value is string[] values)
+                {
+                    foreach (var str in values)
+                        searchEngine.AddFacet(product.Id, prop.Name, str);
+                }
+            }
+        }
+
+        var result = searchEngine.Search("wireless", new Dictionary<string, string>
+        {
+            { "connectivity", "bluetooth"}
+        });
+        Assert.That(result, Has.Length.EqualTo(1));
+        Assert.That(result[0], Is.EqualTo(1));
+
+        result = searchEngine.Search("wireless", new Dictionary<string, string>());
+        Assert.That(result, Has.Length.EqualTo(1));
+
+        result = searchEngine.Search("home", new Dictionary<string, string>());
+        Assert.That(result, Has.Length.EqualTo(3));
+
+        result = searchEngine.Search("home", new Dictionary<string, string>
+        {
+            { "Resolution", "4K UHD"},
+            { "EnergyEfficiency", "A+"},
+        });
+        Assert.That(result, Has.Length.EqualTo(2));
+
+        result = searchEngine.Search("product", new Dictionary<string, string>
+        {
+            { "Resolution", "4K UHD"},
+            { "EnergyEfficiency", "A+"},
+            { "Connectivity", "Bluetooth 5.0" },
+            { "Features", "Milk Frother" },
+        });
+
+        Assert.That(result, Has.Length.EqualTo(4));
+
+        result = searchEngine.Search("", new Dictionary<string, string>
+        {
+            { "Resolution", "4K UHD"},
+            { "EnergyEfficiency", "A+"},
+            { "Connectivity", "Bluetooth 5.0" },
+            { "Features", "Milk Frother" },
+        });
+
+        Assert.That(result, Has.Length.EqualTo(4));
+
+        // Returning all records without providing any criteria is not supported.
+        result = searchEngine.Search(null, new Dictionary<string, string>());
+        Assert.That(result, Is.Empty);
+
+        result = searchEngine.Search("", new Dictionary<string, string>());
+        Assert.That(result, Is.Empty);
+
+        result = searchEngine.Search("");
+        Assert.That(result, Is.Empty);
+    }
+}

--- a/src/ZoneTree.FullTextSearch.UnitTests/HashedSearchEngineTests.cs
+++ b/src/ZoneTree.FullTextSearch.UnitTests/HashedSearchEngineTests.cs
@@ -8,8 +8,11 @@ public class HashedSearchEngineTests
     [Test]
     public void AddRecord_ShouldAddRecordToIndex()
     {
+        var dataPath = "data/AddRecord_ShouldAddRecordToIndex";
+        if (Directory.Exists(dataPath))
+            Directory.Delete(dataPath, true);
         using var searchEngine = new HashedSearchEngine<int>(
-            "data/AddRecord_ShouldAddRecordToIndex");
+            dataPath);
 
         // Arrange
         int record = 1;
@@ -27,8 +30,10 @@ public class HashedSearchEngineTests
     [Test]
     public void DeleteRecord_ShouldRemoveRecordFromIndex()
     {
-        using var searchEngine = new HashedSearchEngine<int>(
-            "data/DeleteRecord_ShouldRemoveRecordFromIndex");
+        var dataPath = "data/DeleteRecord_ShouldRemoveRecordFromIndex";
+        if (Directory.Exists(dataPath))
+            Directory.Delete(dataPath, true);
+        using var searchEngine = new HashedSearchEngine<int>(dataPath);
 
         // Arrange
         int record = 1;
@@ -47,8 +52,10 @@ public class HashedSearchEngineTests
     [Test]
     public void Search_WithRespectTokenOrderTrue_ShouldReturnRecords()
     {
-        using var searchEngine = new HashedSearchEngine<int>(
-            "data/Search_WithRespectTokenOrderTrue_ShouldReturnRecords");
+        var dataPath = "data/Search_WithRespectTokenOrderTrue_ShouldReturnRecords";
+        if (Directory.Exists(dataPath))
+            Directory.Delete(dataPath, true);
+        using var searchEngine = new HashedSearchEngine<int>(dataPath);
 
         // Arrange
         int record1 = 1;
@@ -68,8 +75,10 @@ public class HashedSearchEngineTests
     [Test]
     public void Search_WithRespectTokenOrderFalse_ShouldReturnRecordsRegardlessOfOrder()
     {
-        using var searchEngine = new HashedSearchEngine<int>(
-            "data/Search_WithRespectTokenOrderFalse_ShouldReturnRecordsRegardlessOfOrder");
+        var dataPath = "data/Search_WithRespectTokenOrderFalse_ShouldReturnRecordsRegardlessOfOrder";
+        if (Directory.Exists(dataPath))
+            Directory.Delete(dataPath, true);
+        using var searchEngine = new HashedSearchEngine<int>(dataPath);
 
         // Arrange
         int record1 = 1;
@@ -89,8 +98,10 @@ public class HashedSearchEngineTests
     [Test]
     public void Search_WithSkipAndLimit_ShouldReturnLimitedRecords()
     {
-        using var searchEngine = new HashedSearchEngine<int>(
-            "data/Search_WithSkipAndLimit_ShouldReturnLimitedRecords");
+        var dataPath = "data/Search_WithSkipAndLimit_ShouldReturnLimitedRecords";
+        if (Directory.Exists(dataPath))
+            Directory.Delete(dataPath, true);
+        using var searchEngine = new HashedSearchEngine<int>(dataPath);
 
         // Arrange
         searchEngine.AddRecord(1, "record one");
@@ -109,8 +120,11 @@ public class HashedSearchEngineTests
     public void Dispose_ShouldDisposeIndexProperly()
     {
         // Arrange
-        var searchEngine = new HashedSearchEngine<int>(
-            "data/Dispose_ShouldDisposeIndexProperly");
+        var dataPath = "data/Dispose_ShouldDisposeIndexProperly";
+        if (Directory.Exists(dataPath))
+            Directory.Delete(dataPath, true);
+
+        using var searchEngine = new HashedSearchEngine<int>(dataPath);
         searchEngine.AddRecord(1, "sample");
 
         // Act        

--- a/src/ZoneTree.FullTextSearch.UnitTests/RecordTableTests.cs
+++ b/src/ZoneTree.FullTextSearch.UnitTests/RecordTableTests.cs
@@ -7,7 +7,10 @@ public class RecordTableTests
     [Test]
     public void UpsertRecord_ShouldInsertRecordAndValueIntoBothZoneTrees()
     {
-        using var recordTable = new RecordTable<int, string>("data/UpsertRecord_ShouldInsertRecordAndValueIntoBothZoneTrees");
+        var dataPath = "data/UpsertRecord_ShouldInsertRecordAndValueIntoBothZoneTrees";
+        if (Directory.Exists(dataPath))
+            Directory.Delete(dataPath, true);
+        using var recordTable = new RecordTable<int, string>(dataPath);
 
         // Arrange
         int record = 1;
@@ -26,7 +29,10 @@ public class RecordTableTests
     [Test]
     public void GetLastRecord_ShouldReturnLastInsertedRecord()
     {
-        using var recordTable = new RecordTable<int, string>("data/GetLastRecord_ShouldReturnLastInsertedRecord");
+        var dataPath = "data/GetLastRecord_ShouldReturnLastInsertedRecord";
+        if (Directory.Exists(dataPath))
+            Directory.Delete(dataPath, true);
+        using var recordTable = new RecordTable<int, string>(dataPath);
 
         // Arrange
         int record1 = 1;
@@ -46,7 +52,10 @@ public class RecordTableTests
     [Test]
     public void GetValue_ShouldReturnAssociatedValueForRecord()
     {
-        using var recordTable = new RecordTable<int, string>("data/GetValue_ShouldReturnAssociatedValueForRecord");
+        var dataPath = "data/GetValue_ShouldReturnAssociatedValueForRecord";
+        if (Directory.Exists(dataPath))
+            Directory.Delete(dataPath, true);
+        using var recordTable = new RecordTable<int, string>(dataPath);
 
         // Arrange
         int record = 1;
@@ -63,7 +72,10 @@ public class RecordTableTests
     [Test]
     public void TryGetRecord_ShouldReturnTrueAndRecordWhenValueExists()
     {
-        using var recordTable = new RecordTable<int, string>("data/TryGetRecord_ShouldReturnTrueAndRecordWhenValueExists");
+        var dataPath = "data/TryGetRecord_ShouldReturnTrueAndRecordWhenValueExists";
+        if (Directory.Exists(dataPath))
+            Directory.Delete(dataPath, true);
+        using var recordTable = new RecordTable<int, string>(dataPath);
 
         // Arrange
         int record = 1;
@@ -81,7 +93,10 @@ public class RecordTableTests
     [Test]
     public void TryGetRecord_ShouldReturnFalseWhenValueDoesNotExist()
     {
-        using var recordTable = new RecordTable<int, string>("data/TryGetRecord_ShouldReturnFalseWhenValueDoesNotExist");
+        var dataPath = "data/TryGetRecord_ShouldReturnFalseWhenValueDoesNotExist";
+        if (Directory.Exists(dataPath))
+            Directory.Delete(dataPath, true);
+        using var recordTable = new RecordTable<int, string>(dataPath);
 
         // Act
         bool found = recordTable.TryGetRecord("NonExistentValue", out int _);

--- a/src/ZoneTree.FullTextSearch.UnitTests/ZoneTree.FullTextSearch.UnitTests.csproj
+++ b/src/ZoneTree.FullTextSearch.UnitTests/ZoneTree.FullTextSearch.UnitTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="ZoneTree" Version="1.7.6" />
+    <PackageReference Include="ZoneTree" Version="1.7.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ZoneTree.FullTextSearch.UnitTests/sampleData/ProductList.cs
+++ b/src/ZoneTree.FullTextSearch.UnitTests/sampleData/ProductList.cs
@@ -1,0 +1,211 @@
+﻿namespace ZoneTree.FullTextSearch.UnitTests.sampleData;
+
+public class Product
+{
+    public long Id { get; set; }
+    public string Name { get; set; }
+    public string Category { get; set; }
+    public decimal Price { get; set; }
+    public string Brand { get; set; }
+    public double Rating { get; set; }
+    public Facets Facets { get; set; }
+    public string Description { get; set; }
+
+    public override string ToString()
+    {
+        return $"Product: {Id} {Name} {Category} {Price} {Brand} {Rating} {Description}";
+    }
+}
+
+public class Facets
+{
+    public string Color { get; set; }
+    public string Connectivity { get; set; }
+    public string BatteryLife { get; set; }
+    public string[] Features { get; set; }
+    public string ScreenSize { get; set; }
+    public string Resolution { get; set; }
+    public string[] SmartFeatures { get; set; }
+    public string[] Ports { get; set; }
+    public string Capacity { get; set; }
+    public string EnergyEfficiency { get; set; }
+    public string Processor { get; set; }
+    public string Ram { get; set; }
+    public string Storage { get; set; }
+    public string GraphicsCard { get; set; }
+    public string Pressure { get; set; }
+}
+
+public static class ProductList
+{
+    public static Product[] Products =
+    [
+        new Product
+        {
+            Id = 1,
+            Name = "Wireless Noise Cancelling Headphones",
+            Category = "Electronics",
+            Price = 299.99m,
+            Brand = "AudioPro",
+            Rating = 4.8,
+            Facets = new Facets
+            {
+                Color = "Black",
+                Connectivity = "Bluetooth",
+                BatteryLife = "30 hours",
+                Features = ["Noise Cancelling", "Wireless", "Over-Ear"]
+            },
+            Description = "Experience immersive sound with AudioPro's Wireless Noise Cancelling Headphones. With up to 30 hours of battery life and advanced noise-cancelling technology, these headphones are perfect for uninterrupted music on the go."
+        },
+        new Product
+        {
+            Id = 2,
+            Name = "Smart LED TV 55\" 4K UHD",
+            Category = "Home Appliances",
+            Price = 599.99m,
+            Brand = "VisionTech",
+            Rating = 4.5,
+            Facets = new Facets
+            {
+                ScreenSize = "55 inches",
+                Resolution = "4K UHD",
+                SmartFeatures = ["Voice Control", "Streaming Apps", "Wi-Fi"],
+                Ports = ["HDMI", "USB", "Ethernet"]
+            },
+            Description = "Upgrade your home entertainment with VisionTech's 55\" 4K UHD Smart LED TV. Enjoy stunning visuals and smart features like voice control and streaming apps, all in one sleek package."
+        },
+        new Product
+        {
+            Id = 3,
+            Name = "Stainless Steel Refrigerator",
+            Category = "Home Appliances",
+            Price = 899.99m,
+            Brand = "CoolHome",
+            Rating = 4.7,
+            Facets = new Facets
+            {
+                Capacity = "25 cu. ft.",
+                EnergyEfficiency = "A+",
+                Features = ["Water Dispenser", "Ice Maker", "LED Lighting"],
+                Color = "Stainless Steel"
+            },
+            Description = "Keep your food fresh and organized with CoolHome's 25 cu. ft. Stainless Steel Refrigerator. With a built-in water dispenser and ice maker, this fridge combines style and functionality for any modern kitchen."
+        },
+        new Product
+        {
+            Id = 4,
+            Name = "Gaming Laptop 15\"",
+            Category = "Computers",
+            Price = 1299.99m,
+            Brand = "GamerX",
+            Rating = 4.9,
+            Facets = new Facets
+            {
+                Processor = "Intel i7",
+                Ram = "16GB",
+                Storage = "512GB SSD",
+                GraphicsCard = "NVIDIA GTX 1660 Ti",
+                ScreenSize = "15 inches"
+            },
+            Description = "Take your gaming to the next level with the GamerX 15\" Gaming Laptop. Equipped with an Intel i7 processor and NVIDIA GTX 1660 Ti graphics card, this laptop delivers powerful performance for the most demanding games."
+        },
+        new Product
+        {
+            Id = 5,
+            Name = "Espresso Coffee Machine",
+            Category = "Kitchen Appliances",
+            Price = 199.99m,
+            Brand = "BrewMaster",
+            Rating = 4.6,
+            Facets = new Facets
+            {
+                Capacity = "1.5 liters",
+                Pressure = "15 bar",
+                Features = ["Milk Frother", "Programmable Settings", "Removable Drip Tray"],
+                Color = "Red"
+            },
+            Description = "Brew the perfect cup of espresso with BrewMaster's Espresso Coffee Machine. Featuring a 15 bar pump and programmable settings, this machine makes it easy to enjoy café-quality coffee at home."
+        },
+        new Product
+        {
+            Id = 6,
+            Name = "Smartphone 128GB",
+            Category = "Electronics",
+            Price = 799.99m,
+            Brand = "TechWave",
+            Rating = 4.7,
+            Facets = new Facets
+            {
+                Color = "Midnight Blue",
+                Connectivity = "5G",
+                BatteryLife = "24 hours",
+                Features = ["Face Recognition", "Wireless Charging", "Triple Camera"]
+            },
+            Description = "TechWave's 128GB Smartphone offers cutting-edge technology with 5G connectivity, a powerful battery, and a triple camera system for stunning photos and videos."
+        },
+        new Product
+        {
+            Id = 7,
+            Name = "Electric Mountain Bike",
+            Category = "Outdoor",
+            Price = 1299.99m,
+            Brand = "RideXtreme",
+            Rating = 4.8,
+            Facets = new Facets
+            {
+                Color = "Matte Black",
+                BatteryLife = "60 miles",
+                Features = ["Pedal Assist", "Hydraulic Brakes", "Shock Absorbers"]
+            },
+            Description = "Explore the outdoors with RideXtreme's Electric Mountain Bike, featuring a powerful motor, long battery life, and advanced suspension for all-terrain adventures."
+        },
+        new Product
+        {
+            Id = 8,
+            Name = "4K Action Camera",
+            Category = "Cameras",
+            Price = 249.99m,
+            Brand = "AdventureCam",
+            Rating = 4.4,
+            Facets = new Facets
+            {
+                Color = "Silver",
+                Connectivity = "Wi-Fi",
+                Features = ["Waterproof", "Image Stabilization", "4K Video"]
+            },
+            Description = "Capture every moment with the AdventureCam 4K Action Camera. Its waterproof design and image stabilization make it perfect for any adventure."
+        },
+        new Product
+        {
+            Id = 9,
+            Name = "Digital Air Fryer",
+            Category = "Kitchen Appliances",
+            Price = 99.99m,
+            Brand = "HealthyCook",
+            Rating = 4.5,
+            Facets = new Facets
+            {
+                Capacity = "5 liters",
+                Features = ["Touch Screen", "Adjustable Temperature", "Non-stick Basket"],
+                Color = "White"
+            },
+            Description = "HealthyCook's Digital Air Fryer makes healthy cooking easy. With a large capacity and touch screen controls, you can fry, bake, and grill your favorite meals with little to no oil."
+        },
+        new Product
+        {
+            Id = 10,
+            Name = "Portable Bluetooth Speaker",
+            Category = "Electronics",
+            Price = 49.99m,
+            Brand = "SoundBlitz",
+            Rating = 4.3,
+            Facets = new Facets
+            {
+                Color = "Camo Green",
+                Connectivity = "Bluetooth 5.0",
+                BatteryLife = "12 hours",
+                Features = ["Waterproof", "Built-in Microphone", "Stereo Pairing"]
+            },
+            Description = "Enjoy high-quality sound on the go with the SoundBlitz Portable Bluetooth Speaker. Its waterproof design and long battery life make it perfect for any adventure."
+        }];
+}


### PR DESCRIPTION
### Adding Facets

To associate a facet (e.g., category, author) with a record:

```csharp
searchEngine.AddFacet(1, "category", "books");
searchEngine.AddFacet(1, "author", "John Doe");
```

### Deleting Facets

To remove a specific facet associated with a record:

```csharp
searchEngine.DeleteFacet(1, "category", "books");
searchEngine.DeleteFacet(1, "author", "John Doe");
```

### Faceted Search

If you're also filtering by facets, you can still apply pagination by specifying the `skip` and `limit` parameters:

```csharp
var facets = new Dictionary<string, string>
{
    { "category", "books" },
    { "author", "John Doe" }
};

var paginatedFacetedResultsPage1 = searchEngine.Search(
    search: "quick fox",
    facets: facets,
    respectTokenOrder: true,
    skip: 0, // Start from the first matching record
    limit: 10 // Retrieve up to 10 records
);

var paginatedFacetedResultsPage2 = searchEngine.Search(
    search: "quick fox",
    facets: facets,
    respectTokenOrder: true,
    skip: 10, // Skip the first 10 matching records
    limit: 10 // Retrieve the next 10 records
);
```