### PR TITLE
Improve performance, avoid redundant seeks by tracking unmatched records during the search process.

### DIFF
--- a/src/ZoneTree.FullTextSearch.Playground/SearchEngineApp.cs
+++ b/src/ZoneTree.FullTextSearch.Playground/SearchEngineApp.cs
@@ -20,6 +20,8 @@ public sealed class SearchEngineApp : IDisposable
 
     readonly bool UseDiacriticNormalizer = false;
 
+    readonly bool IndexInBackground = false;
+
     readonly HashedSearchEngine<long> SearchEngine;
 
     readonly RecordTable<long, string> RecordTable;
@@ -66,7 +68,10 @@ public sealed class SearchEngineApp : IDisposable
                 {
                     case "1":
                         var o = ConfigureIndex();
-                        CreateIndex(o.indexPath, o.pattern, true);
+                        if (IndexInBackground)
+                            Task.Run(() => CreateIndex(o.indexPath, o.pattern, false));
+                        else
+                            CreateIndex(o.indexPath, o.pattern, true);
                         break;
                     case "2":
                         Search();

--- a/src/ZoneTree.FullTextSearch/Directory.Build.props
+++ b/src/ZoneTree.FullTextSearch/Directory.Build.props
@@ -5,8 +5,8 @@
     <Authors>Ahmed Yasin Koculu</Authors>
     <PackageId>ZoneTree.FullTextSearch</PackageId>
     <Title>ZoneTree.FullTextSearch</Title>
-    <ProductVersion>1.0.3.0</ProductVersion>
-    <Version>1.0.3.0</Version>
+    <ProductVersion>1.0.4.0</ProductVersion>
+    <Version>1.0.4.0</Version>
     <Authors>Ahmed Yasin Koculu</Authors>
     <AssemblyTitle>ZoneTree.FullTextSearch</AssemblyTitle>
     <Description>ZoneTree.FullTextSearch is an open-source library that extends ZoneTree to provide efficient full-text search capabilities. It offers a fast, embedded search engine suitable for applications that require high performance and do not rely on external databases.</Description>

--- a/src/ZoneTree.FullTextSearch/Index/IndexOfTokenRecordPreviousToken.cs
+++ b/src/ZoneTree.FullTextSearch/Index/IndexOfTokenRecordPreviousToken.cs
@@ -20,6 +20,18 @@ public sealed class IndexOfTokenRecordPreviousToken<TRecord, TToken>
     where TRecord : unmanaged
     where TToken : unmanaged
 {
+    readonly bool useSecondaryIndex;
+
+    bool isDropped;
+
+    bool isDisposed;
+
+    readonly SearchOnIndexOfTokenRecordPreviousToken<TRecord, TToken>
+        searchAlgorithm;
+
+    readonly AdvancedSearchOnIndexOfTokenRecordPreviousToken<TRecord, TToken>
+        advancedSearchAlgorithm;
+
     /// <summary>
     /// Gets the primary zone tree used to store and retrieve records by token and previous token.
     /// </summary>
@@ -70,15 +82,10 @@ public sealed class IndexOfTokenRecordPreviousToken<TRecord, TToken>
         }
     }
 
-    readonly bool useSecondaryIndex;
-
-    bool isDropped = false;
-
-    readonly SearchOnIndexOfTokenRecordPreviousToken<TRecord, TToken>
-        searchAlgorithm;
-
-    readonly AdvancedSearchOnIndexOfTokenRecordPreviousToken<TRecord, TToken>
-        advancedSearchAlgorithm;
+    /// <summary>
+    /// Returns true if the index is dropped, otherwise false.
+    /// </summary>
+    public bool IsIndexDropped { get => isDropped; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IndexOfTokenRecordPreviousToken{TRecord, TToken}"/> class,
@@ -164,11 +171,6 @@ public sealed class IndexOfTokenRecordPreviousToken<TRecord, TToken>
         if (isDropped) throw new Exception($"{nameof(
             IndexOfTokenRecordPreviousToken<TRecord, TToken>)} is dropped.");
     }
-
-    /// <summary>
-    /// Returns true if the index is dropped, otherwise false.
-    /// </summary>
-    public bool IsIndexDropped { get => isDropped; }
 
     /// <summary>
     /// Evicts data from memory to disk in both primary and secondary zone trees.
@@ -400,8 +402,6 @@ public sealed class IndexOfTokenRecordPreviousToken<TRecord, TToken>
     {
         return advancedSearchAlgorithm.Search(query, cancellationToken);
     }
-
-    bool isDisposed = false;
 
     /// <summary>
     /// Disposes the resources used by the index.

--- a/src/ZoneTree.FullTextSearch/Index/IndexOfTokenRecordPreviousToken.cs
+++ b/src/ZoneTree.FullTextSearch/Index/IndexOfTokenRecordPreviousToken.cs
@@ -119,7 +119,8 @@ public sealed class IndexOfTokenRecordPreviousToken<TRecord, TToken>
             tokenComparer = ComponentsForKnownTypes.GetComparer<TToken>();
         var factory1 = new ZoneTreeFactory<CompositeKeyOfTokenRecordPrevious<TRecord, TToken>, byte>()
             .SetDataDirectory($"{dataPath}/index1")
-            .SetIsValueDeletedDelegate((in byte x) => x == 1)
+            .SetIsDeletedDelegate(
+                (in CompositeKeyOfTokenRecordPrevious<TRecord, TToken> key, in byte value) => value == 1)
             .SetMarkValueDeletedDelegate((ref byte x) => x = 1)
             .SetKeySerializer(new StructSerializer<CompositeKeyOfTokenRecordPrevious<TRecord, TToken>>())
             .SetComparer(
@@ -142,7 +143,8 @@ public sealed class IndexOfTokenRecordPreviousToken<TRecord, TToken>
         {
             var factory2 = new ZoneTreeFactory<CompositeKeyOfRecordToken<TRecord, TToken>, byte>()
                 .SetDataDirectory($"{dataPath}/index2")
-                .SetIsValueDeletedDelegate((in byte x) => x == 1)
+                .SetIsDeletedDelegate(
+                    (in CompositeKeyOfRecordToken<TRecord, TToken> key, in byte value) => value == 1)
                 .SetMarkValueDeletedDelegate((ref byte x) => x = 1)
                 .SetKeySerializer(new StructSerializer<CompositeKeyOfRecordToken<TRecord, TToken>>())
                 .SetComparer(
@@ -239,7 +241,7 @@ public sealed class IndexOfTokenRecordPreviousToken<TRecord, TToken>
             Record = record,
             Token = token,
         };
-        ZoneTree2.TryAdd(key, new());
+        ZoneTree2.TryAdd(key, new(), out _);
     }
 
     /// <summary>

--- a/src/ZoneTree.FullTextSearch/Model/CompositeKeyOfRecordToken.cs
+++ b/src/ZoneTree.FullTextSearch/Model/CompositeKeyOfRecordToken.cs
@@ -10,7 +10,9 @@ namespace ZoneTree.FullTextSearch.Model;
 /// <typeparam name="TRecord">The type of the record component of the key. Must be an unmanaged type.</typeparam>
 /// <typeparam name="TToken">The type of the token component of the key. Must be an unmanaged type.</typeparam>
 [StructLayout(LayoutKind.Sequential)]
-public struct CompositeKeyOfRecordToken<TRecord, TToken> : IEquatable<CompositeKeyOfRecordToken<TRecord, TToken>> where TRecord : unmanaged
+public struct CompositeKeyOfRecordToken<TRecord, TToken>
+    : IEquatable<CompositeKeyOfRecordToken<TRecord, TToken>>
+    where TRecord : unmanaged
     where TToken : unmanaged
 {
     /// <summary>

--- a/src/ZoneTree.FullTextSearch/Model/CompositeKeyOfTokenRecordPrevious.cs
+++ b/src/ZoneTree.FullTextSearch/Model/CompositeKeyOfTokenRecordPrevious.cs
@@ -10,7 +10,9 @@ namespace ZoneTree.FullTextSearch;
 /// <typeparam name="TRecord">The type of the record component of the key. Must be an unmanaged type.</typeparam>
 /// <typeparam name="TToken">The type of the token components of the key. Must be an unmanaged type.</typeparam>
 [StructLayout(LayoutKind.Sequential)]
-public struct CompositeKeyOfTokenRecordPrevious<TRecord, TToken> : IEquatable<CompositeKeyOfTokenRecordPrevious<TRecord, TToken>> where TRecord : unmanaged
+public struct CompositeKeyOfTokenRecordPrevious<TRecord, TToken>
+    : IEquatable<CompositeKeyOfTokenRecordPrevious<TRecord, TToken>>
+    where TRecord : unmanaged
     where TToken : unmanaged
 {
     /// <summary>

--- a/src/ZoneTree.FullTextSearch/Search/AdvancedSearchOnIndexOfTokenRecordPreviousToken.cs
+++ b/src/ZoneTree.FullTextSearch/Search/AdvancedSearchOnIndexOfTokenRecordPreviousToken.cs
@@ -284,7 +284,10 @@ public sealed class AdvancedSearchOnIndexOfTokenRecordPreviousToken<TRecord, TTo
                     if (records.Contains(record)) continue;
 
                     if (!DoesRecordMatchesTheQuery(query.QueryNode, record))
+                    {
+                        skipRecords.Add(record);
                         continue;
+                    }
 
                     if (off >= skip)
                     {
@@ -325,7 +328,10 @@ public sealed class AdvancedSearchOnIndexOfTokenRecordPreviousToken<TRecord, TTo
                 if (records.Contains(record)) continue;
 
                 if (!DoesRecordMatchesTheQuery(query.QueryNode, record))
+                {
+                    skipRecords.Add(record);
                     continue;
+                }
 
                 if (off >= skip)
                 {

--- a/src/ZoneTree.FullTextSearch/Search/SearchOnIndexOfTokenRecordPreviousToken.cs
+++ b/src/ZoneTree.FullTextSearch/Search/SearchOnIndexOfTokenRecordPreviousToken.cs
@@ -174,7 +174,6 @@ public sealed class SearchOnIndexOfTokenRecordPreviousToken<TRecord, TToken>
             int skip,
             int limit)
         {
-            var skipRecords = new HashSet<TRecord>();
             var records = new HashSet<TRecord>();
             iterator1.Seek(new CompositeKeyOfTokenRecordPrevious<TRecord, TToken>()
             {
@@ -199,14 +198,9 @@ public sealed class SearchOnIndexOfTokenRecordPreviousToken<TRecord, TToken>
                 // different previous token.
                 if (records.Contains(record)) continue;
 
-                if (skipRecords.Contains(record)) continue;
-
                 if (!DoesRecordContainAllTokens(tokens, record) ||
                     !DoesRecordContainAnyOfTheFacets(facets, record))
-                {
-                    skipRecords.Add(record);
                     continue;
-                }
 
                 if (off >= skip)
                 {

--- a/src/ZoneTree.FullTextSearch/Search/SearchOnIndexOfTokenRecordPreviousToken.cs
+++ b/src/ZoneTree.FullTextSearch/Search/SearchOnIndexOfTokenRecordPreviousToken.cs
@@ -174,6 +174,7 @@ public sealed class SearchOnIndexOfTokenRecordPreviousToken<TRecord, TToken>
             int skip,
             int limit)
         {
+            var skipRecords = new HashSet<TRecord>();
             var records = new HashSet<TRecord>();
             iterator1.Seek(new CompositeKeyOfTokenRecordPrevious<TRecord, TToken>()
             {
@@ -198,11 +199,14 @@ public sealed class SearchOnIndexOfTokenRecordPreviousToken<TRecord, TToken>
                 // different previous token.
                 if (records.Contains(record)) continue;
 
-                if (!DoesRecordContainAllTokens(tokens, record))
-                    continue;
+                if (skipRecords.Contains(record)) continue;
 
-                if (!DoesRecordContainAnyOfTheFacets(facets, record))
+                if (!DoesRecordContainAllTokens(tokens, record) ||
+                    !DoesRecordContainAnyOfTheFacets(facets, record))
+                {
+                    skipRecords.Add(record);
                     continue;
+                }
 
                 if (off >= skip)
                 {

--- a/src/ZoneTree.FullTextSearch/SearchEngines/HashedSearchEngine.cs
+++ b/src/ZoneTree.FullTextSearch/SearchEngines/HashedSearchEngine.cs
@@ -413,7 +413,7 @@ public sealed class HashedSearchEngine<TRecord> : IDisposable
         Index.Drop();
     }
 
-    bool isDisposed = false;
+    bool isDisposed;
 
     /// <summary>
     /// Disposes the resources used by the search engine.

--- a/src/ZoneTree.FullTextSearch/ZoneTree.FullTextSearch.csproj
+++ b/src/ZoneTree.FullTextSearch/ZoneTree.FullTextSearch.csproj
@@ -38,7 +38,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ZoneTree" Version="1.8.0" />
+    <PackageReference Include="ZoneTree" Version="1.8.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Improve search performance
The current search algorithm does not retain a list of unmatched records, leading to repeated seeks for the same record. 

To improve performance, avoid redundant seeks by tracking unmatched records during the search process.